### PR TITLE
fixed using gzipped response in json_encode

### DIFF
--- a/Model/Client/Deepl.php
+++ b/Model/Client/Deepl.php
@@ -106,7 +106,7 @@ class Deepl implements TranslatorInterface
             $this->_handleError($result);
         }
 
-        $translate = json_decode($result->getContent(), true);
+        $translate = json_decode($result->getBody(), true);
 
         if (!isset($translate['translations'][0]['text'])) {
             throw new LocalizedException(__('Translation is empty.'));
@@ -137,7 +137,7 @@ class Deepl implements TranslatorInterface
             $this->_handleError($result);
         }
 
-        $usage = json_decode($result->getContent(), true);
+        $usage = json_decode($result->getBody(), true);
 
         if (!isset($usage['character_count'])) {
             throw new LocalizedException(__('Usage is empty.'));


### PR DESCRIPTION
Deepl started using gzip encoding in responses in their API calls which can't be handled by `json_decode`. My simple changes fix that so JSON is passed. 